### PR TITLE
Enhance chart with grid lines and scroll

### DIFF
--- a/vega_drilldown_shape_timeline.json
+++ b/vega_drilldown_shape_timeline.json
@@ -93,6 +93,13 @@
         }
       ]
     },
+    {"name": "needsScroll", "update": "scaledHeight > height"},
+    {"name": "yScroll", "value": 0, "on": [
+      {"events": "@scrollThumb:pointerdown", "update": "0"},
+      {"events": "[@scrollThumb:pointerdown, window:pointerup] > window:pointermove", 
+       "update": "clamp(yScroll + (event.movementY * (scaledHeight - height) / (height - 20)), 0, max(0, scaledHeight - height))"},
+      {"events": "wheel!", "update": "x() < columnsWidth ? clamp(yScroll + event.deltaY * 3, 0, max(0, scaledHeight - height)) : yScroll"}
+    ]},
     {
       "type": "group",
       "name": "scrollbar",
@@ -100,7 +107,7 @@
         "update": {
           "x": {"signal": "columnsWidth + ganttWidth + 5"},
           "y": {"value": 0},
-          "width": {"value": 10},
+          "width": {"value": 15},
           "height": {"signal": "height"},
           "fill": {"value": "transparent"},
           "opacity": {"signal": "needsScroll ? 1 : 0"}
@@ -127,12 +134,16 @@
           "name": "scrollThumb",
           "encode": {
             "update": {
-              "x": {"value": 1},
-              "y": {"signal": "(yScroll / (data('yScale').length * yRowHeight - height)) * (height - (height * height / (data('yScale').length * yRowHeight)))"},
-              "width": {"value": 6},
-              "height": {"signal": "max(20, height * height / (data('yScale').length * yRowHeight))"},
-              "fill": {"value": "#999"},
-              "cornerRadius": {"value": 3}
+              "x": {"value": 2},
+              "y": {"signal": "needsScroll ? (yScroll / (scaledHeight - height)) * (height - max(20, height * height / scaledHeight)) : 0"},
+              "width": {"value": 11},
+              "height": {"signal": "needsScroll ? max(20, height * height / scaledHeight) : 0"},
+              "fill": {"value": "#666"},
+              "cornerRadius": {"value": 3},
+              "cursor": {"value": "pointer"}
+            },
+            "hover": {
+              "fill": {"value": "#333"}
             }
           }
         }
@@ -162,7 +173,7 @@
     {"name": "scaledHeight", "update": "data('yScale').length * yRowHeight"},
     {
       "name": "yRange",
-      "update": "[yRange!=null?yRange[0]:0,yRange!=null?yRange[0]+scaledHeight:scaledHeight]",
+      "update": "[yScroll, yScroll + height]",
       "on": [
         {
           "events": [{"signal": "delta"}],
@@ -171,7 +182,11 @@
         {"events": "dblclick", "update": "[0,scaledHeight]"},
         {
           "events": {"signal": "closeAll"},
-          "update": "closeAll?[0, scaledHeight]:yRange"
+          "update": "closeAll?[yScroll, yScroll + height]:yRange"
+        },
+        {
+          "events": {"signal": "yScroll"},
+          "update": "[yScroll, yScroll + height]"
         }
       ]
     },
@@ -399,7 +414,7 @@
             "project_end",
             "continuum"
           ],
-          "ops": ["min", "max", "values"],
+          "ops": ["min", "max", "distinct"],
           "as": ["project_start", "project_end", "continuum"],
           "groupby": ["project", "phase"]
         },
@@ -409,7 +424,7 @@
         {
           "type": "formula",
           "as": "continuum",
-          "expr": "datum.continuum[0]"
+          "expr": "isArray(datum.continuum) ? join(datum.continuum, ', ') : datum.continuum"
         },
         {
           "type": "window",
@@ -536,6 +551,32 @@
         {"side": "right", "text": "Months", "x": 150},
         {"side": "right", "text": "Days", "x": 200, "leftRadius": 4}
       ]
+    },
+    {
+      "name": "organizationBoundaries",
+      "source": "yScale",
+      "transform": [
+        {
+          "type": "aggregate",
+          "fields": ["finalSort"],
+          "ops": ["max"],
+          "as": ["maxSort"],
+          "groupby": ["project"]
+        },
+        {
+          "type": "lookup",
+          "from": "yScale",
+          "key": "finalSort",
+          "values": ["id"],
+          "fields": ["maxSort"],
+          "as": ["lastId"]
+        },
+        {
+          "type": "formula",
+          "as": "y",
+          "expr": "scale('y', datum.lastId) + bandwidth('y')"
+        }
+      ]
     }
   ],
   "marks": [
@@ -642,6 +683,24 @@
           "height": {"signal": "bandwidth('y')"},
           "fill": {"value": "#dceaf7"},
           "opacity": {"value": 0.3}
+        }
+      }
+    },
+    {
+      "name": "organizationGridLines",
+      "description": "Horizontal grid lines for each Organization group",
+      "type": "rule",
+      "clip": true,
+      "zindex": 1,
+      "from": {"data": "organizationBoundaries"},
+      "encode": {
+        "update": {
+          "x": {"value": 0},
+          "x2": {"signal": "columnsWidth + ganttWidth"},
+          "y": {"signal": "datum.y"},
+          "stroke": {"value": "#cccccc"},
+          "strokeWidth": {"value": 1.5},
+          "opacity": {"value": 0.7}
         }
       }
     },

--- a/vega_drilldown_shape_timeline.json
+++ b/vega_drilldown_shape_timeline.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Modified Gantt Chart - Shape-based Activity View for Medical Education",
-  "autosize": "pad",
+  "autosize": {"type": "fit", "resize": true},
   "width": 1200,
   "padding": {"left": 5, "right": 0, "top": 5, "bottom": 0},
   "signals": [
-    {"name": "height", "update": "500"},
+    {"name": "minHeight", "value": 300, "description": "Minimum height of the visual"},
+    {"name": "maxHeight", "value": 800, "description": "Maximum height before scrolling kicks in"},
+    {"name": "heightPadding", "value": 100, "description": "Extra padding for dynamic height calculation"},
+    {"name": "enableDynamicHeight", "value": true, "description": "Enable/disable dynamic height"},
+    {"name": "dynamicHeight", "update": "enableDynamicHeight ? max(minHeight, min(maxHeight, data('yScale').length * yRowHeight + heightPadding)) : 500"},
+    {"name": "height", "update": "dynamicHeight"},
     {"name": "showTooltips", "value": true},
     {"name": "showButtons", "value": true},
     {"name": "showDomainSpanLabel", "value": false},
@@ -93,12 +98,13 @@
         }
       ]
     },
-    {"name": "needsScroll", "update": "scaledHeight > height"},
+    {"name": "needsScroll", "update": "scaledHeight > height && height >= maxHeight"},
     {"name": "yScroll", "value": 0, "on": [
       {"events": "@scrollThumb:pointerdown", "update": "0"},
       {"events": "[@scrollThumb:pointerdown, window:pointerup] > window:pointermove", 
        "update": "clamp(yScroll + (event.movementY * (scaledHeight - height) / (height - 20)), 0, max(0, scaledHeight - height))"},
-      {"events": "wheel!", "update": "x() < columnsWidth ? clamp(yScroll + event.deltaY * 3, 0, max(0, scaledHeight - height)) : yScroll"}
+      {"events": "wheel!", "update": "x() < columnsWidth ? clamp(yScroll + event.deltaY * 3, 0, max(0, scaledHeight - height)) : yScroll"},
+      {"events": {"signal": "dynamicHeight"}, "update": "needsScroll ? clamp(yScroll, 0, max(0, scaledHeight - height)) : 0"}
     ]},
     {
       "type": "group",
@@ -173,20 +179,24 @@
     {"name": "scaledHeight", "update": "data('yScale').length * yRowHeight"},
     {
       "name": "yRange",
-      "update": "[yScroll, yScroll + height]",
+      "update": "needsScroll ? [yScroll, yScroll + height] : [0, scaledHeight]",
       "on": [
         {
           "events": [{"signal": "delta"}],
-          "update": "clampRange( [yCur[0] + span(yCur) * delta[1] / scaledHeight, yCur[1] + span(yCur) * delta[1] / scaledHeight],height>=scaledHeight?0: height-scaledHeight,height>=scaledHeight?height:scaledHeight)"
+          "update": "needsScroll ? clampRange( [yCur[0] + span(yCur) * delta[1] / scaledHeight, yCur[1] + span(yCur) * delta[1] / scaledHeight], 0, scaledHeight - height) : [0, scaledHeight]"
         },
-        {"events": "dblclick", "update": "[0,scaledHeight]"},
+        {"events": "dblclick", "update": "needsScroll ? [0, height] : [0, scaledHeight]"},
         {
           "events": {"signal": "closeAll"},
-          "update": "closeAll?[yScroll, yScroll + height]:yRange"
+          "update": "needsScroll ? [yScroll, yScroll + height] : [0, scaledHeight]"
         },
         {
           "events": {"signal": "yScroll"},
-          "update": "[yScroll, yScroll + height]"
+          "update": "needsScroll ? [yScroll, yScroll + height] : [0, scaledHeight]"
+        },
+        {
+          "events": {"signal": "dynamicHeight"},
+          "update": "needsScroll ? [yScroll, yScroll + height] : [0, scaledHeight]"
         }
       ]
     },


### PR DESCRIPTION
Add horizontal grid lines to visually separate organization groups, implement a vertical scrollbar for improved navigation, and display all distinct learner continuum levels when phases are collapsed for accurate aggregation.

---
<a href="https://cursor.com/background-agent?bcId=bc-54a93405-ee10-4fa2-8941-a26db6e71d98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54a93405-ee10-4fa2-8941-a26db6e71d98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

